### PR TITLE
feat : 리뷰 좋아요, 좋아요 해제 기능

### DIFF
--- a/src/main/java/com/example/demo/global/converter/SearchConditionConverter.java
+++ b/src/main/java/com/example/demo/global/converter/SearchConditionConverter.java
@@ -1,11 +1,12 @@
 package com.example.demo.global.converter;
 
 import com.example.demo.review.domain.vo.SearchCondition;
+import jakarta.annotation.Nonnull;
 import org.springframework.core.convert.converter.Converter;
 
 public class SearchConditionConverter implements Converter<String, SearchCondition> {
     @Override
-    public SearchCondition convert(String name) {
+    public SearchCondition convert(@Nonnull String name) {
         return SearchCondition.getInstance(name);
     }
 }

--- a/src/main/java/com/example/demo/review/application/ReviewService.java
+++ b/src/main/java/com/example/demo/review/application/ReviewService.java
@@ -83,6 +83,12 @@ public class ReviewService {
 
         return ReviewResponseDTO.of(review);
     }
+    public List<ReviewResponseDTO> findByLikes(){
+        return reviewRepository.findByLikes()
+                .stream()
+                .map(ReviewResponseDTO::of)
+                .toList();
+    }
 
     public void deleteReview(Long id){
         // TODO: 2/7/24 삭제 부분 좋아요 등은 남길지? 그렇다면 FK를 사용할지? 혹은 소프트딜리트 할지?

--- a/src/main/java/com/example/demo/review/application/ReviewService.java
+++ b/src/main/java/com/example/demo/review/application/ReviewService.java
@@ -15,7 +15,8 @@ import com.example.demo.spot.application.SpotService;
 import com.example.demo.spot.domain.Spot;
 import com.example.demo.user.domain.entity.Users;
 
-import com.example.demo.user.user.service.UserService;
+
+import com.example.demo.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -35,12 +36,11 @@ public class ReviewService {
     public Long write(final ReviewRequest reviewRequest,
                       final String nickName,
                       final Long spotId,
-                      final String weatherDescription){
+                      final Weather weather){
         final String title = reviewRequest.title();
         final String content = reviewRequest.content();
         final Spot spot = spotService.findById(spotId);
         final Users user = userService.findByNickName(nickName);
-        final Weather weather= Weather.getInstance(weatherDescription);
 
         final Review review = Review.builder()
                 .title(new Title(title))
@@ -55,12 +55,12 @@ public class ReviewService {
     }
     @Transactional
     public void updateReview(final Long reviewId,
-                             final ReviewWriteRequest reviewRequest){
+                             final ReviewWriteRequest reviewRequest,
+                             final Weather weather){
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(
                         () -> new ReviewException.ReviewNotFoundException(reviewId)
                 );
-        Weather weather = Weather.getInstance(reviewRequest.weatherDescription());
         review.update(weather,
                 new Title(reviewRequest.title()),
                 new Content(reviewRequest.content())

--- a/src/main/java/com/example/demo/review/domain/Review.java
+++ b/src/main/java/com/example/demo/review/domain/Review.java
@@ -4,10 +4,13 @@ import com.example.demo.global.domain.BaseTimeEntity;
 import com.example.demo.review.domain.vo.Content;
 import com.example.demo.review.domain.vo.Title;
 import com.example.demo.review.domain.vo.Weather;
+import com.example.demo.review_like.domain.ReviewLike;
 import com.example.demo.spot.domain.Spot;
 import com.example.demo.user.domain.entity.Users;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.LinkedHashSet;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,6 +30,8 @@ public class Review extends BaseTimeEntity {
     private Users users;
     @ManyToOne(fetch = FetchType.LAZY)
     private Spot spot;
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private LinkedHashSet<ReviewLike> reviewLikes;
     @Builder
     public Review(Title title, Content content, Weather weather, Users users, Spot spot) {
         this.title = title;

--- a/src/main/java/com/example/demo/review/domain/Review.java
+++ b/src/main/java/com/example/demo/review/domain/Review.java
@@ -4,13 +4,10 @@ import com.example.demo.global.domain.BaseTimeEntity;
 import com.example.demo.review.domain.vo.Content;
 import com.example.demo.review.domain.vo.Title;
 import com.example.demo.review.domain.vo.Weather;
-import com.example.demo.review_like.domain.ReviewLike;
 import com.example.demo.spot.domain.Spot;
 import com.example.demo.user.domain.entity.Users;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.util.LinkedHashSet;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,8 +27,6 @@ public class Review extends BaseTimeEntity {
     private Users users;
     @ManyToOne(fetch = FetchType.LAZY)
     private Spot spot;
-    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
-    private LinkedHashSet<ReviewLike> reviewLikes;
     @Builder
     public Review(Title title, Content content, Weather weather, Users users, Spot spot) {
         this.title = title;

--- a/src/main/java/com/example/demo/review/domain/ReviewQueryRepository.java
+++ b/src/main/java/com/example/demo/review/domain/ReviewQueryRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface ReviewQueryRepository {
     // 한방쿼리
     List<Review> findByTagNames(List<TagName> tagNames, SearchCondition searchCondition);
+
+    List<Review> findByLikes();
 }

--- a/src/main/java/com/example/demo/review/domain/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/review/domain/ReviewQueryRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,24 +20,45 @@ import static com.example.demo.review_tag.domain.QTag.tag;
 @RequiredArgsConstructor
 public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     private final JPAQueryFactory queryFactory;
-    // 한방쿼리
 
+    // TODO: 2/9/24 이 쿼리 leftJoin 처리하면 결과가 나올 것임. 그러나 태그 엔티티 작업 후 테스트하기로...
     @Override
-    @Transactional(readOnly = true)
-    public List<Review> findByTagNames(List<TagName> tagNames, SearchCondition searchCondition) {
-        return queryFactory
-                .select(review)
-                .distinct()
-                .from(review)
-                .innerJoin(review, reviewTag.review)
-                .innerJoin(reviewTag.tag, tag)
-                .where(
-                        this.searchByTagNames(tagNames)
-                        )
+    public List<Review> findByTagNames(List<TagName> tags, SearchCondition searchCondition){
+        List<Long> taggedReviews = this.findTaggedReviews(tags);
+        return queryFactory.selectFrom(review)
+                .innerJoin(reviewTag)
+                .on(review.id.eq(reviewTag.review.id))
+                .where(searchByTagNamesIfPresent(taggedReviews))
+                .innerJoin(reviewLike)
+                .on(reviewLike.review.id.eq(review.id))
                 .groupBy(review)
                 .orderBy(this.getOrder(searchCondition))
                 .fetch();
     }
+
+    @Override
+    public List<Review> findByLikes() {
+        return queryFactory.selectFrom(review)
+                .leftJoin(review.reviewLikes, reviewLike)
+                .groupBy(review.id) // 리뷰의 id로 그룹화하여
+                .orderBy(reviewLike.count().desc(), review.createdDate.desc()) // reviewLike의 개수로 내림차순 정렬
+                .limit(20) // 상위 20개 리뷰만 선택
+                .fetch();
+    }
+
+    private List<Long> findTaggedReviews(List<TagName> tags){
+        return queryFactory.select(reviewTag.id)
+                .from(reviewTag)
+                .innerJoin(tag)
+                .on(tag.id.eq(reviewTag.tag.id))
+                .where(searchByTagNames(tags))
+                .fetch();
+    }
+
+    private BooleanExpression searchByTagNamesIfPresent(List<Long> taggedReviews){
+        return taggedReviews == null || taggedReviews.isEmpty() ? null : reviewTag.id.in(taggedReviews);
+    }
+
     private BooleanExpression searchByTagNames(List<TagName> tagNames){
         return tagNames == null || tagNames.isEmpty() ? null : tag.name.in(tagNames);
     }

--- a/src/main/java/com/example/demo/review/domain/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/review/domain/ReviewQueryRepositoryImpl.java
@@ -30,7 +30,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
                 .on(review.id.eq(reviewTag.review.id))
                 .where(searchByTagNamesIfPresent(taggedReviews))
                 .innerJoin(reviewLike)
-                .on(reviewLike.review.id.eq(review.id))
+                .on(reviewLike.reviewLikeId.reviewId.eq(review.id))
                 .groupBy(review)
                 .orderBy(this.getOrder(searchCondition))
                 .fetch();
@@ -39,7 +39,8 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     @Override
     public List<Review> findByLikes() {
         return queryFactory.selectFrom(review)
-                .leftJoin(review.reviewLikes, reviewLike)
+                .leftJoin(reviewLike)
+                .on(reviewLike.reviewLikeId.reviewId.eq(review.id))
                 .groupBy(review.id) // 리뷰의 id로 그룹화하여
                 .orderBy(reviewLike.count().desc(), review.createdDate.desc()) // reviewLike의 개수로 내림차순 정렬
                 .limit(20) // 상위 20개 리뷰만 선택

--- a/src/main/java/com/example/demo/review/domain/vo/ReviewId.java
+++ b/src/main/java/com/example/demo/review/domain/vo/ReviewId.java
@@ -1,0 +1,4 @@
+package com.example.demo.review.domain.vo;
+
+public record ReviewId(Long value) {
+}

--- a/src/main/java/com/example/demo/review/presentation/ReviewController.java
+++ b/src/main/java/com/example/demo/review/presentation/ReviewController.java
@@ -85,4 +85,17 @@ public class ReviewController {
         List<ReviewResponseDTO> result = reviewService.findByTagNames(tags, searchCondition);
         return ResponseEntity.ok(result);
     }
+
+    // TODO: 2/9/24 URI 어떻게 할 것인지 정해야 한다.
+    @GetMapping("/api/main/reviews")
+    @Operation(summary = "리뷰 조회(리스트)", description = "좋아요를 많이 받은 순으로 20개의 리뷰를 조회합니다.")
+    public ResponseEntity<List<ReviewResponseDTO>> get20ReviewsByLikes(){
+        List<ReviewResponseDTO> result = reviewService.findByLikes();
+
+        if (result == null || result.isEmpty()){
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/com/example/demo/review_like/ReviewLikeQueryRepository.java
+++ b/src/main/java/com/example/demo/review_like/ReviewLikeQueryRepository.java
@@ -1,7 +1,4 @@
 package com.example.demo.review_like;
 
-import java.util.List;
-
 public interface ReviewLikeQueryRepository {
-    List<Long> getReviewByLikesDesc();
 }

--- a/src/main/java/com/example/demo/review_like/ReviewLikeQueryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/review_like/ReviewLikeQueryRepositoryImpl.java
@@ -4,21 +4,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
-import static com.example.demo.review_like.domain.QReviewLike.reviewLike;
-
 @Repository
 @RequiredArgsConstructor
 public class ReviewLikeQueryRepositoryImpl implements ReviewLikeQueryRepository{
     private final JPAQueryFactory queryFactory;
-    @Override
-    public List<Long> getReviewByLikesDesc(){
-        return queryFactory
-                .select(reviewLike.review.id)
-                .from(reviewLike)
-                .groupBy(reviewLike.review.id)
-                .orderBy(reviewLike.count().desc())
-                .fetch();
-    }
 }

--- a/src/main/java/com/example/demo/review_like/ReviewLikeRepository.java
+++ b/src/main/java/com/example/demo/review_like/ReviewLikeRepository.java
@@ -1,7 +1,9 @@
 package com.example.demo.review_like;
 
 import com.example.demo.review_like.domain.ReviewLike;
+import com.example.demo.review_like.domain.vo.ReviewLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long>, ReviewLikeQueryRepository {
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, ReviewLikeId>, ReviewLikeQueryRepository {
+
 }

--- a/src/main/java/com/example/demo/review_like/application/ReviewLikeService.java
+++ b/src/main/java/com/example/demo/review_like/application/ReviewLikeService.java
@@ -1,0 +1,38 @@
+package com.example.demo.review_like.application;
+
+import com.example.demo.review.domain.vo.ReviewId;
+import com.example.demo.review_like.ReviewLikeRepository;
+import com.example.demo.review_like.domain.ReviewLike;
+import com.example.demo.review_like.domain.vo.ReviewLikeId;
+import com.example.demo.user.domain.entity.vo.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class ReviewLikeService {
+    private final ReviewLikeRepository reviewLikeRepository;
+
+    // TODO: 2/9/24 이 두 매서드에서 throw를 할지 말지 고민해보자 (무조건 200으로 줄지?)
+    //  더불어서 동시성문제를 생각할지?
+    public void like(UserId userId, ReviewId reviewId) {
+        Optional<ReviewLike> reviewLike = reviewLikeRepository.findById(new ReviewLikeId(userId, reviewId));
+
+        if (reviewLike.isPresent()) {
+            return;
+        }
+
+        reviewLikeRepository.save(new ReviewLike(
+                userId,
+                reviewId
+        ));
+    }
+
+    public void unlike(UserId userId, ReviewId reviewId) {
+       reviewLikeRepository.findById(new ReviewLikeId(userId, reviewId))
+                // 있을 경우에만 delete
+                .ifPresent(reviewLikeRepository::delete);
+    }
+}

--- a/src/main/java/com/example/demo/review_like/domain/ReviewLike.java
+++ b/src/main/java/com/example/demo/review_like/domain/ReviewLike.java
@@ -1,8 +1,9 @@
 package com.example.demo.review_like.domain;
 
 import com.example.demo.global.domain.BaseTimeEntity;
-import com.example.demo.review.domain.Review;
-import com.example.demo.user.domain.entity.Users;
+import com.example.demo.review.domain.vo.ReviewId;
+import com.example.demo.review_like.domain.vo.ReviewLikeId;
+import com.example.demo.user.domain.entity.vo.UserId;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -10,16 +11,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewLike extends BaseTimeEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Review review;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Users users;
-
-    public ReviewLike(Review review, Users users) {
-        this.review = review;
-        this.users = users;
+    @EmbeddedId
+    private ReviewLikeId reviewLikeId;
+    public ReviewLike(UserId userId, ReviewId reviewId) {
+        this.reviewLikeId = new ReviewLikeId(userId, reviewId);
     }
 }

--- a/src/main/java/com/example/demo/review_like/domain/ReviewLike.java
+++ b/src/main/java/com/example/demo/review_like/domain/ReviewLike.java
@@ -17,4 +17,9 @@ public class ReviewLike extends BaseTimeEntity {
     private Review review;
     @ManyToOne(fetch = FetchType.LAZY)
     private Users users;
+
+    public ReviewLike(Review review, Users users) {
+        this.review = review;
+        this.users = users;
+    }
 }

--- a/src/main/java/com/example/demo/review_like/domain/vo/ReviewLikeId.java
+++ b/src/main/java/com/example/demo/review_like/domain/vo/ReviewLikeId.java
@@ -1,0 +1,23 @@
+package com.example.demo.review_like.domain.vo;
+
+import com.example.demo.review.domain.vo.ReviewId;
+import com.example.demo.user.domain.entity.vo.UserId;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReviewLikeId implements Serializable {
+    private Long userId;
+    private Long reviewId;
+
+    public ReviewLikeId(UserId userId, ReviewId reviewId) {
+        this.userId = userId.value();
+        this.reviewId = reviewId.value();
+    }
+}

--- a/src/main/java/com/example/demo/review_like/presentation/ReviewLikeController.java
+++ b/src/main/java/com/example/demo/review_like/presentation/ReviewLikeController.java
@@ -1,0 +1,54 @@
+package com.example.demo.review_like.presentation;
+
+import com.example.demo.jwt.CustomUserDetails;
+import com.example.demo.review.domain.vo.ReviewId;
+import com.example.demo.review_like.application.ReviewLikeService;
+import com.example.demo.user.domain.entity.vo.UserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@Tag(name = "Review Controller", description = "리뷰 컨트롤러")
+@SecurityRequirement(name = "Bearer Authentication")
+public class ReviewLikeController {
+    private final ReviewLikeService reviewLikeService;
+
+    @PostMapping("/api/reviews/like/{review-id}")
+    @Operation(summary = "리뷰 좋아요", description = "리뷰에 좋아요를 등록합니다")
+    public ResponseEntity<Void> likeReview(
+            @PathVariable(value = "review-id") Long reviewIdValue,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        final UserId userId = new UserId(userDetails.getUsers().getId());
+        final ReviewId reviewId = new ReviewId(reviewIdValue);
+
+        reviewLikeService.like(userId, reviewId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/reviews/like/{review-id}")
+    @Operation(summary = "리뷰 좋아요 삭제", description = "리뷰의 좋아요를 삭제합니다")
+    public ResponseEntity<Void> unlikeReview(
+            @PathVariable(value = "review-id") Long reviewIdValue,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        final UserId userId = new UserId(userDetails.getUsers().getId());
+        final ReviewId reviewId = new ReviewId(reviewIdValue);
+
+        reviewLikeService.unlike(userId, reviewId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/review_tag/domain/ReviewTag.java
+++ b/src/main/java/com/example/demo/review_tag/domain/ReviewTag.java
@@ -13,8 +13,10 @@ public class ReviewTag {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "REVIEW_ID")
     private Review review;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "TAG_ID")
     private Tag tag;
 }

--- a/src/main/java/com/example/demo/spot/domain/vo/Location.java
+++ b/src/main/java/com/example/demo/spot/domain/vo/Location.java
@@ -9,6 +9,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Location {
-    private Double latitude; // 위도
-    private Double longitude; // 경도
+    private String latitude; // 위도
+    private String longitude; // 경도
+
+    public Location(String latitude, String longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 }

--- a/src/main/java/com/example/demo/spot/dto/SpotResponse.java
+++ b/src/main/java/com/example/demo/spot/dto/SpotResponse.java
@@ -5,8 +5,8 @@ import com.example.demo.spot.domain.Spot;
 public record SpotResponse ( Long id,
                              String displayName, // "소플러스 제주점~"
                              String formattedAddress,// "대한민국 ~도 ~시 ~로 111"
-                             Double latitude,
-                             Double longitude
+                             String latitude,
+                             String longitude
 ) {
     public static SpotResponse of(Spot spot){
         return new SpotResponse(

--- a/src/main/java/com/example/demo/user/domain/entity/vo/UserId.java
+++ b/src/main/java/com/example/demo/user/domain/entity/vo/UserId.java
@@ -1,0 +1,6 @@
+package com.example.demo.user.domain.entity.vo;
+
+
+public record UserId (Long value) {
+}
+

--- a/src/test/java/com/example/demo/common/Repositories.java
+++ b/src/test/java/com/example/demo/common/Repositories.java
@@ -1,0 +1,39 @@
+package com.example.demo.common;
+
+import com.example.demo.review.domain.ReviewRepository;
+import com.example.demo.review_like.ReviewLikeRepository;
+import com.example.demo.spot.domain.SpotRepository;
+import com.example.demo.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Repositories {
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private SpotRepository spotRepository;
+
+    @Autowired
+    private ReviewLikeRepository reviewLikeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public ReviewRepository getReviewRepository() {
+        return reviewRepository;
+    }
+
+    public SpotRepository getSpotRepository() {
+        return spotRepository;
+    }
+
+    public ReviewLikeRepository getReviewLikeRepository() {
+        return reviewLikeRepository;
+    }
+
+    public UserRepository getUserRepository() {
+        return userRepository;
+    }
+}

--- a/src/test/java/com/example/demo/common/RepositoryFactory.java
+++ b/src/test/java/com/example/demo/common/RepositoryFactory.java
@@ -1,0 +1,35 @@
+package com.example.demo.common;
+
+import com.example.demo.review.domain.Review;
+import com.example.demo.review_like.domain.ReviewLike;
+import com.example.demo.spot.domain.Spot;
+import com.example.demo.user.domain.entity.Users;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RepositoryFactory {
+    @Autowired
+    private Repositories repositories;
+
+    public Users saveUser(Users users){
+        return repositories.getUserRepository().save(users);
+    }
+    public Spot saveSpot(Spot spot){
+        return repositories.getSpotRepository().save(spot);
+    }
+
+    public Review saveReview(Review review){
+        return repositories.getReviewRepository().save(review);
+    }
+
+    public List<Review> saveAllReviewAndFlush(List<Review> reviewList){
+        return repositories.getReviewRepository().saveAllAndFlush(reviewList);
+    }
+
+    public ReviewLike saveReviewLike(ReviewLike reviewLike){
+        return repositories.getReviewLikeRepository().save(reviewLike);
+    }
+}

--- a/src/test/java/com/example/demo/common/RepositoryTest.java
+++ b/src/test/java/com/example/demo/common/RepositoryTest.java
@@ -1,0 +1,12 @@
+package com.example.demo.common;
+
+import com.example.demo.config.AutoConfigureRepositoryTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import(value = {Repositories.class, RepositoryFactory.class})
+@AutoConfigureRepositoryTest
+public abstract class RepositoryTest {
+    @Autowired
+    protected RepositoryFactory repositoryFactory;
+}

--- a/src/test/java/com/example/demo/config/AutoConfigureRepositoryTest.java
+++ b/src/test/java/com/example/demo/config/AutoConfigureRepositoryTest.java
@@ -1,0 +1,24 @@
+package com.example.demo.config;
+
+
+import com.example.demo.common.Repositories;
+import com.example.demo.common.RepositoryFactory;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@DataJpaTest // JPA Repoository TEST
+@ExtendWith(SpringExtension.class) // JUnit 등 Spring Extends enable
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(value = {Repositories.class, RepositoryFactory.class, TestQueryDslConfig.class})
+public @interface AutoConfigureRepositoryTest {
+}

--- a/src/test/java/com/example/demo/config/TestQueryDslConfig.java
+++ b/src/test/java/com/example/demo/config/TestQueryDslConfig.java
@@ -1,0 +1,24 @@
+package com.example.demo.config;
+
+import com.example.demo.review.domain.ReviewQueryRepositoryImpl;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public ReviewQueryRepositoryImpl reviewQueryRepository() {
+        return new ReviewQueryRepositoryImpl(jpaQueryFactory());
+    }
+}

--- a/src/test/java/com/example/demo/review/domain/ReviewQueryRepositoryImplTest.java
+++ b/src/test/java/com/example/demo/review/domain/ReviewQueryRepositoryImplTest.java
@@ -1,0 +1,102 @@
+package com.example.demo.review.domain;
+
+import com.example.demo.common.RepositoryTest;
+import com.example.demo.review.domain.vo.Content;
+import com.example.demo.review.domain.vo.Title;
+import com.example.demo.review.domain.vo.Weather;
+import com.example.demo.review_like.domain.ReviewLike;
+import com.example.demo.spot.domain.Spot;
+import com.example.demo.spot.domain.vo.Location;
+import com.example.demo.user.domain.entity.Role;
+import com.example.demo.user.domain.entity.Users;
+import com.example.demo.user.domain.enums.Gender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReviewQueryRepositoryImplTest extends RepositoryTest {
+    @Autowired
+    ReviewQueryRepositoryImpl reviewQueryRepository;
+    private static final String TEST_DISPLAY_NAME = "TEST";
+    private static final String TEST = "TEST";
+    private static final String TEST_LATITUDE = "33.489793999999996";
+    private static final String TEST_LONGITUDE = "41.489182847399996";
+
+    private static final Spot SPOT = new Spot(
+            TEST_DISPLAY_NAME,
+            TEST,
+            new Location(TEST_LATITUDE,
+                    TEST_LONGITUDE)
+    );
+
+    private static final Users USERS = new Users("email",
+            "nickname",
+            "imageUrl",
+            Gender.MALE,
+            LocalDate.now(),
+            "authId",
+            Role.USER
+    );
+
+    @BeforeEach
+    void setUp() {
+        repositoryFactory.saveSpot(SPOT);
+        repositoryFactory.saveUser(USERS);
+        saveHundredReviewEntities();
+    }
+
+    // 리뷰 엔티티 100개 저장, 81-100 엔티티는 좋아요 저장
+    void saveHundredReviewEntities() {
+        List<Review> list = IntStream.range(0, 100)
+                .mapToObj(
+                        value -> {
+                            return new Review(
+                                    new Title(TEST + value),
+                                    new Content(TEST),
+                                    Weather.SNOWY,
+                                    USERS,
+                                    SPOT
+                            );
+                        }
+                ).toList();
+
+        repositoryFactory.saveAllReviewAndFlush(list);
+
+        // 80 번 째 이후로 저장
+        for (int i = 80; i < list.size(); i++) {
+            repositoryFactory.saveReviewLike(new ReviewLike(list.get(i), USERS));
+        }
+    }
+
+    @Test
+    void find20ByLikes_SIZE_IS_20() {
+        final List<Review> byLikes = reviewQueryRepository.findByLikes();
+        assertThat(byLikes).hasSize(20);
+    }
+
+    @Test
+    @DisplayName("좋아요 수가 동률이라면 최신순으로 정렬한다.")
+    void find20ByLikes_ORDERS() {
+        List<Review> byLikes = reviewQueryRepository.findByLikes();
+
+        Review review = byLikes.get(0); // 맨 첫번째 유닛, 계속 재할당된다
+        for (int i = 1; i < byLikes.size(); i++) {
+            // 좋아요 수는 현재 동률이므로, 먼저 오는 녀석의 날짜는
+            LocalDateTime first = review.getCreatedDate();
+            // 나중에 오는 녀석의 날짜보다
+            LocalDateTime last = byLikes.get(i).getCreatedDate();
+            // 항상 앞선다 (나중이다_
+            assertThat(first.isAfter(last)).isTrue();
+            // 처음에 올 녀석을 재할당한다
+            review = byLikes.get(i);
+        }
+    }
+}

--- a/src/test/java/com/example/demo/review/domain/ReviewQueryRepositoryImplTest.java
+++ b/src/test/java/com/example/demo/review/domain/ReviewQueryRepositoryImplTest.java
@@ -2,6 +2,7 @@ package com.example.demo.review.domain;
 
 import com.example.demo.common.RepositoryTest;
 import com.example.demo.review.domain.vo.Content;
+import com.example.demo.review.domain.vo.ReviewId;
 import com.example.demo.review.domain.vo.Title;
 import com.example.demo.review.domain.vo.Weather;
 import com.example.demo.review_like.domain.ReviewLike;
@@ -9,6 +10,7 @@ import com.example.demo.spot.domain.Spot;
 import com.example.demo.spot.domain.vo.Location;
 import com.example.demo.user.domain.entity.Role;
 import com.example.demo.user.domain.entity.Users;
+import com.example.demo.user.domain.entity.vo.UserId;
 import com.example.demo.user.domain.enums.Gender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -91,7 +93,8 @@ class ReviewQueryRepositoryImplTest extends RepositoryTest {
 
         // 80 번 째 이후로 저장
         for (int i = 80; i < list.size(); i++) {
-            repositoryFactory.saveReviewLike(new ReviewLike(list.get(i), USERS));
+            ReviewLike reviewLike = new ReviewLike(new UserId(1L), new ReviewId((long) i));
+            repositoryFactory.saveReviewLike(reviewLike);
         }
     }
 
@@ -108,10 +111,10 @@ class ReviewQueryRepositoryImplTest extends RepositoryTest {
         Review review = repositoryFactory.saveReview(REVIEW);
         Review review2 = repositoryFactory.saveReview(REVIEW);
         // when
-        repositoryFactory.saveReviewLike(new ReviewLike(review, USERS));
-        repositoryFactory.saveReviewLike(new ReviewLike(review, USERS2));
+        repositoryFactory.saveReviewLike(new ReviewLike(new UserId(1L), new ReviewId(101L)));
+        repositoryFactory.saveReviewLike(new ReviewLike(new UserId(2L), new ReviewId(101L)));
         // 102 번째 엔티티도 저장 (생성 내림차순이 아님을 테스트 하기 위함)
-        repositoryFactory.saveReviewLike(new ReviewLike(review2, USERS));
+        repositoryFactory.saveReviewLike(new ReviewLike(new UserId(1L), new ReviewId(102L)));
 
         // then
         List<Review> byLikes = reviewQueryRepository.findByLikes();


### PR DESCRIPTION
1. 리뷰 좋아요 엔티티의 아이디 생성 방식을 composite PK 로 바꾸었습니다.

2. userId, reviewId 등등 Long 타입으로 관리되던 값들은 감싸는 VO record 를 만들었습니다.

